### PR TITLE
Add option to start as REST or socket.io servers

### DIFF
--- a/config/moviebot_config_no_integration.yaml
+++ b/config/moviebot_config_no_integration.yaml
@@ -19,7 +19,8 @@ TELEGRAM: False # execute the code on Telegram
 
 POLLING: False # True when using Telegram without server
 
-FLASK: True # run with Flask
+FLASK_SOCKET: False
+FLASK_REST: True
 
 BOT_TOKEN_PATH: config/bot_token.yaml
 

--- a/moviebot/agent/agent.py
+++ b/moviebot/agent/agent.py
@@ -106,8 +106,10 @@ class Agent:
         self.nlg = NLG(dict(ontology=self.ontology))
         data_config["slots"] = list(self.nlu.intents_checker.slot_values.keys())
 
-        self.isBot = self.config.get("TELEGRAM", False) or self.config.get(
-            "FLASK", False
+        self.isBot = (
+            self.config.get("TELEGRAM", False)
+            or self.config.get("FLASK_REST", False)
+            or self.config.get("FLASK_SOCKET", False)
         )
 
         self.dialogue_manager = DialogueManager(

--- a/moviebot/run.py
+++ b/moviebot/run.py
@@ -15,7 +15,7 @@ import logging
 
 import confuse
 
-from moviebot.controller import server_socket
+from moviebot.controller import server_rest, server_socket
 from moviebot.controller.controller_telegram import ControllerTelegram
 from moviebot.controller.controller_terminal import ControllerTerminal
 
@@ -67,8 +67,10 @@ if __name__ == "__main__":
     if config["TELEGRAM"].get(False):
         CONTROLLER = ControllerTelegram()
         CONTROLLER.execute_agent(config.get())
-    elif config["FLASK"].get(False):
+    elif config["FLASK_SOCKET"].get(False):
         server_socket.run(config.get())
+    elif config["FLASK_REST"].get(False):
+        server_rest.run(config.get())
     else:
         CONTROLLER = ControllerTerminal(config.get())
         CONTROLLER.execute_agent()


### PR DESCRIPTION
Add option in configuration to choose the type of Flask server.

Fixes #156